### PR TITLE
✨ Add amount > 0 checking when setting ISCN reward map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 ## [Unreleased]
+### Changed
+- Breaking: `calculateStakeholderRewards()` would not set a Map value if `amount` is not larger than 0
+- Breaking: `calculateStakeholderRewards()` amount set into `defaultWallet` now also respect `precision`
+- `parseStakeholderAddresses()` now accept `precision` as optional parameter.
+
 
 ## [0.4.2] - 2022-11-18
 ### Fixed

--- a/src/iscn/parsing.test.ts
+++ b/src/iscn/parsing.test.ts
@@ -269,6 +269,28 @@ describe('stakeholderRatioCalculation', () => {
     expect(res).toEqual(LIKEMap);
   });
 
+  test('parseAndCalculateStakeholderRewards precision 0 input 0.1 ', async () => {
+    const res = await parseAndCalculateStakeholderRewards(iscnDataMainnet2, 'defaultWalletForTest', { LIKE_CO_API_ROOT: 'https://api.like.co', totalAmount: '0.1', precision: 0 });
+    const LIKEMap = new Map();
+    LIKEMap.set('defaultWalletForTest', { amount: '0' });
+    expect(res).toEqual(LIKEMap);
+  });
+
+  test('parseAndCalculateStakeholderRewards precision 0 input 1.1', async () => {
+    const res = await parseAndCalculateStakeholderRewards(iscnDataMainnet2, 'defaultWalletForTest', { LIKE_CO_API_ROOT: 'https://api.like.co', totalAmount: '1.1', precision: 0 });
+    const LIKEMap = new Map();
+    LIKEMap.set('defaultWalletForTest', { amount: '1' });
+    expect(res).toEqual(LIKEMap);
+  });
+
+  test('parseAndCalculateStakeholderRewards precision 0 input 10.1', async () => {
+    const res = await parseAndCalculateStakeholderRewards(iscnDataMainnet2, 'defaultWalletForTest', { LIKE_CO_API_ROOT: 'https://api.like.co', totalAmount: '10.1', precision: 0 });
+    const LIKEMap = new Map();
+    LIKEMap.set('like156gedr03g3ggwktzhygfusax4df46k8dh6w0me', { amount: '5' });
+    LIKEMap.set('like1tej2qstg4q255s620ld74gyvw0nzhklu8aezr5', { amount: '5' });
+    expect(res).toEqual(LIKEMap);
+  });
+
   test('parseAndCalculateStakeholderRewards testnet ', async () => {
     const res = await parseAndCalculateStakeholderRewards(iscnDataTestnet2, 'defaultWalletForTest', { LIKE_CO_API_ROOT: 'https://api.rinkeby.like.co', totalAmount: '100' });
     const LIKEMap = new Map();

--- a/src/iscn/parsing.ts
+++ b/src/iscn/parsing.ts
@@ -53,11 +53,14 @@ export function calculateStakeholderRewards(
       const amount = new BigNumber(
         weight.times(totalAmount).div(totalWeight).toFixed(precision, BigNumber.ROUND_DOWN),
       );
-      LIKEMap.set(address, { amount: amount.toFixed() });
+      if (amount && amount.gt(0)) LIKEMap.set(address, { amount: amount.toFixed() });
     });
   }
   if (LIKEMap.size === 0) {
-    LIKEMap.set(defaultWallet, { amount: new BigNumber(totalAmount).toFixed() });
+    const amount = new BigNumber(totalAmount).toFixed(precision, BigNumber.ROUND_DOWN);
+    LIKEMap.set(defaultWallet, {
+      amount: new BigNumber(amount).toFixed(),
+    });
   }
   return LIKEMap;
 }
@@ -90,14 +93,16 @@ export async function parseStakeholderAddresses(
 export async function parseAndCalculateStakeholderRewards(
   iscnData: ISCNRecordData,
   defaultWallet: string,
-  { LIKE_CO_API_ROOT = 'https://api.like.co', totalAmount = '1' }: { LIKE_CO_API_ROOT?: string, totalAmount?: string | number } = {},
+  { LIKE_CO_API_ROOT = 'https://api.like.co', totalAmount = '1', precision = 9 }: {
+    LIKE_CO_API_ROOT?: string, totalAmount?: string | number, precision?: number,
+  } = {},
 )
 : Promise < Map < string, { amount: string } > > {
   const parsedIscnData = await parseStakeholderAddresses(iscnData, { LIKE_CO_API_ROOT });
   const map = calculateStakeholderRewards(
     parsedIscnData,
     defaultWallet,
-    { totalAmount },
+    { totalAmount, precision },
   );
   return map;
 }


### PR DESCRIPTION
- Don't set entry in reward map if amount not >0
- Expose precision param in `parseAndCalculateStakeholderRewards()`
- Use same precision setting for default wallet