### PR TITLE
🐛 Stringify metadata to HTML safe string

### DIFF
--- a/src/iscn/iscnId.test.ts
+++ b/src/iscn/iscnId.test.ts
@@ -48,6 +48,13 @@ const iscnSignPayloadEmpty = {
   contentMetadata: {},
 } as ISCNSignPayload;
 
+const iscnSignPayloadToEscape = {
+  recordNotes: '<>&\u2028\u2029\u2029\u2028&><',
+  contentFingerprints: [],
+  stakeholders: [],
+  contentMetadata: {},
+} as ISCNSignPayload;
+
 describe('getMsgCreateIscnRecordJSON', () => {
   test('Test basic message', async () => {
     const res = getMsgCreateISCNRecordJSON(
@@ -117,5 +124,13 @@ describe('getISCNId', () => {
       1,
     );
     expect(res).toEqual('9BTHkP5NiO_Zo2L5rnXy7H4bGocv3qZp7UH82kYVvjY');
+  });
+
+  test('Test message with chars need to be escaped', async () => {
+    const res = getISCNIdPrefix(
+      sender,
+      iscnSignPayloadToEscape,
+    );
+    expect(res).toEqual('42NjT3XiIHNOrZL54UJb0QDoZOyaVAPfB_9cmgrlqeM');
   });
 });

--- a/src/iscn/iscnId.ts
+++ b/src/iscn/iscnId.ts
@@ -43,10 +43,21 @@ export function getMsgCreateISCNRecordJSON(
   return jsonStableStringify(obj);
 }
 
+// reference to: https://pkg.go.dev/encoding/json#Marshal
+function escapeUnsafeChar(s: string): string {
+  return s
+    .replace(/</g, '\\u003c')
+    .replace(/>/g, '\\u003e')
+    .replace(/&/g, '\\u0026')
+    .replace(/\u2028/g, '\\u2028')
+    .replace(/\u2029/g, '\\u2029');
+}
+
 export function getISCNIdPrefix(from: string, payload: ISCNSignPayload, nonce = 0, registryName = 'likecoin-chain'): string {
   const json = getMsgCreateISCNRecordJSON(from, payload, nonce);
+  const escaped = escapeUnsafeChar(json);
   const sha256 = createHash('sha256');
-  return sha256.update(`${registryName}/${json}`).digest('base64')
+  return sha256.update(`${registryName}/${escaped}`).digest('base64')
     .replace(/\+/g, '-')
     .replace(/\//g, '_')
     .replace(/=/g, '');


### PR DESCRIPTION
According to Go's [json.Marshal doc](https://pkg.go.dev/encoding/json#Marshal):
>String values encode as JSON strings coerced to valid UTF-8, replacing invalid bytes with the Unicode replacement rune. So that the JSON will be safe to embed inside HTML <script> tags, the string is encoded using HTMLEscape, which replaces "<", ">", "&", U+2028, and U+2029 are escaped to "\u003c","\u003e", "\u0026", "\u2028", and "\u2029".

Characters "<", ">", and "&" should be manually replaced with Unicode.

<img width="1027" alt="截圖 2023-07-17 下午1 42 56" src="https://github.com/likecoin/iscn-js/assets/33746295/594c2cb7-801a-4153-9bb5-f9129ce5ab0f">
